### PR TITLE
Feature: PollMutex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,6 @@ mod rwlock;
 mod semaphore;
 
 pub use barrier::{Barrier, BarrierWaitResult};
-pub use mutex::{Mutex, MutexGuard, MutexGuardArc};
+pub use mutex::{Mutex, MutexGuard, MutexGuardArc, PollMutex};
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
 pub use semaphore::{Semaphore, SemaphoreGuard, SemaphoreGuardArc};

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,7 +1,8 @@
-use std::sync::Arc;
 use std::thread;
+use std::{sync::Arc, task::Poll};
 
-use async_lock::Mutex;
+use async_lock::{Mutex, PollMutex};
+use future::poll_fn;
 use futures_lite::future;
 
 #[test]
@@ -57,6 +58,81 @@ fn contention() {
 
         for _ in 0..num_tasks {
             rx.recv().await.unwrap();
+        }
+
+        let lock = mutex.lock().await;
+        assert_eq!(num_tasks, *lock);
+    });
+}
+
+#[test]
+fn poll_lock() {
+    future::block_on(async {
+        poll_fn(|cx| -> Poll<()> {
+            let m = Arc::new(Mutex::new(()));
+            let mut m1 = PollMutex::new(m.clone());
+            let mut m2 = PollMutex::new(m.clone());
+            let guard = m1.poll_lock(cx);
+            if let Poll::Ready(guard) = guard {
+                assert!(m2.poll_lock(cx).is_pending());
+                drop(guard);
+                assert!(m2.poll_lock(cx).is_ready());
+            } else {
+                unreachable!();
+            }
+            Poll::Ready(())
+        })
+        .await;
+    })
+}
+
+#[test]
+fn poll_lock_arc() {
+    future::block_on(async {
+        poll_fn(|cx| -> Poll<()> {
+            let m = Arc::new(Mutex::new(()));
+            let mut m1 = PollMutex::new(m.clone());
+            let mut m2 = PollMutex::new(m.clone());
+            let guard = m1.poll_lock(cx);
+            if let Poll::Ready(guard) = guard {
+                assert!(m2.poll_lock_arc(cx).is_pending());
+                drop(guard);
+                assert!(m2.poll_lock_arc(cx).is_ready());
+            } else {
+                unreachable!();
+            }
+            Poll::Ready(())
+        })
+        .await;
+    })
+}
+
+#[test]
+fn contention_poll_lock_arc() {
+    future::block_on(async {
+        let (tx, rx) = async_channel::unbounded();
+
+        let tx = Arc::new(tx);
+        let mutex = Arc::new(Mutex::new(0i32));
+        let num_tasks = 100;
+
+        for _ in 0..num_tasks {
+            let tx = tx.clone();
+            let mutex = mutex.clone();
+            let mut mutex = PollMutex::new(mutex);
+
+            thread::spawn(|| {
+                future::block_on(async move {
+                    let mut lock = future::poll_fn(|cx| mutex.poll_lock_arc(cx)).await;
+                    *lock += 1;
+                    tx.send(()).await.unwrap();
+                    drop(lock);
+                })
+            });
+        }
+
+        for _ in 0..num_tasks {
+            rx.recv().await.unwrap()
         }
 
         let lock = mutex.lock().await;


### PR DESCRIPTION
Related issue: #4

`PollMutex` is a simple wrapper of Mutex, which can acquire the mutex guard in sync code, efficiently.

I'm not sure if the name `PollMutex` is suitable. XD

