### PR TITLE
🌐 Add WASM Support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,6 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ matrix.rust }}
+            target: wasm32-unknown-unknown
             profile: minimal
             override: true
 
@@ -36,6 +37,12 @@ jobs:
         with:
           command: check
           args: --all --benches --examples --tests -Z features=dev_dep
+
+      - name: Run cargo check for WASM
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --all --bins --examples --tests --all-features --target wasm32-unknown-unknown
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,6 +25,9 @@ jobs:
             profile: minimal
             override: true
 
+      - name: Install WASM Test Tools
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -43,6 +46,9 @@ jobs:
         with:
           command: check
           args: --all --bins --examples --tests --all-features --target wasm32-unknown-unknown
+
+      - name: Test WASM
+        run: wasm-pack test --headless --chrome
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ event-listener = "2.5.1"
 async-channel = "1.5.0"
 fastrand = "1.4.0"
 futures-lite = "1.11.0"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -4,7 +4,10 @@ use std::ops::{Deref, DerefMut};
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
+
 use std::usize;
 
 use event_listener::Event;
@@ -110,6 +113,7 @@ impl<T: ?Sized> Mutex<T> {
     #[cold]
     async fn acquire_slow(&self) {
         // Get the current time.
+        #[cfg(not(target_arch = "wasm32"))]
         let start = Instant::now();
 
         loop {
@@ -158,6 +162,7 @@ impl<T: ?Sized> Mutex<T> {
 
             // If waiting for too long, fall back to a fairer locking strategy that will prevent
             // newer lock operations from starving us forever.
+            #[cfg(not(target_arch = "wasm32"))]
             if start.elapsed() > Duration::from_micros(500) {
                 break;
             }

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::thread;
 
 use async_lock::Barrier;
-use futures_lite::future;
+use futures_lite::future; 
 
 #[test]
 fn smoke() {

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,10 +1,19 @@
-use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::thread;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
 
 use async_lock::Mutex;
 use futures_lite::future;
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::*;
+
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn smoke() {
     future::block_on(async {
         let m = Mutex::new(());
@@ -14,24 +23,28 @@ fn smoke() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn try_lock() {
     let m = Mutex::new(());
     *m.try_lock().unwrap() = ();
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn into_inner() {
     let m = Mutex::new(10i32);
     assert_eq!(m.into_inner(), 10);
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn get_mut() {
     let mut m = Mutex::new(10i32);
     *m.get_mut() = 20;
     assert_eq!(m.into_inner(), 20);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn contention() {
     future::block_on(async {


### PR DESCRIPTION
Still, testing, but would you be open to supporting WASM? It looks like all that is needed is an extra dep for supporting `std::time::Instant` on web.

It's behind a feature flag so it doesn't effect anybody unconcerned with WASM.