### PR TITLE
Simplify using lock_arc

### DIFF
--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,4 +1,3 @@
-#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread;
@@ -75,4 +74,13 @@ fn contention() {
         let lock = mutex.lock().await;
         assert_eq!(num_tasks, *lock);
     });
+}
+
+#[test]
+fn lifetime() {
+    // Show that the future keeps the mutex alive.
+    let _fut = {
+        let mutex = Arc::new(Mutex::new(0i32));
+        mutex.lock_arc()
+    };
 }


### PR DESCRIPTION
The future returned by lock_arc would already resolve to a
MutexGuardArc that kept the Arc<Mutex> alive. Unfortunately, sometimes
one needs to store the future itself, not the MutexGuardArc and the
future had a reference to the Arc<Mutex>.

With this patch, the future itself also has a Arc<Mutex>.