### PR TITLE
Simplify wasm tests

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -6,6 +6,7 @@ use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+// Note: we cannot use `target_family = "wasm"` here because it requires Rust 1.54.
 #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
 use std::time::{Duration, Instant};
 

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,18 +1,17 @@
 use std::sync::Arc;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use std::thread;
 
 use async_lock::Mutex;
 use futures_lite::future;
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn smoke() {
     future::block_on(async {
         let m = Mutex::new(());
@@ -22,28 +21,25 @@ fn smoke() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn try_lock() {
     let m = Mutex::new(());
     *m.try_lock().unwrap() = ();
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn into_inner() {
     let m = Mutex::new(10i32);
     assert_eq!(m.into_inner(), 10);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn get_mut() {
     let mut m = Mutex::new(10i32);
     *m.get_mut() = 20;
     assert_eq!(m.into_inner(), 20);
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn contention() {
     future::block_on(async {

--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -1,24 +1,24 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use futures_lite::prelude::*;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use std::future::Future;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 use std::thread;
 
 use futures_lite::future;
 
 use async_lock::{RwLock, RwLockUpgradableReadGuard};
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen_test::*;
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 fn spawn<T: Send + 'static>(f: impl Future<Output = T> + Send + 'static) -> future::Boxed<T> {
     let (s, r) = async_channel::bounded(1);
     thread::spawn(move || {
@@ -30,7 +30,6 @@ fn spawn<T: Send + 'static>(f: impl Future<Output = T> + Send + 'static) -> futu
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn smoke() {
     future::block_on(async {
         let lock = RwLock::new(());
@@ -42,7 +41,6 @@ fn smoke() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn try_write() {
     future::block_on(async {
         let lock = RwLock::new(0isize);
@@ -53,14 +51,12 @@ fn try_write() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn into_inner() {
     let lock = RwLock::new(10);
     assert_eq!(lock.into_inner(), 10);
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn into_inner_and_drop() {
     struct Counter(Arc<AtomicUsize>);
 
@@ -83,14 +79,13 @@ fn into_inner_and_drop() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn get_mut() {
     let mut lock = RwLock::new(10);
     *lock.get_mut() = 20;
     assert_eq!(lock.into_inner(), 20);
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn contention() {
     const N: u32 = 10;
@@ -124,7 +119,7 @@ fn contention() {
     });
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[test]
 fn writer_and_readers() {
     let lock = Arc::new(RwLock::new(0i32));
@@ -171,7 +166,6 @@ fn writer_and_readers() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn upgrade() {
     future::block_on(async {
         let lock: RwLock<i32> = RwLock::new(0);
@@ -202,7 +196,6 @@ fn upgrade() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn not_upgrade() {
     future::block_on(async {
         let mutex: RwLock<i32> = RwLock::new(0);
@@ -234,7 +227,6 @@ fn not_upgrade() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn upgradable_with_concurrent_writer() {
     future::block_on(async {
         let lock: Arc<RwLock<i32>> = Arc::new(RwLock::new(0));


### PR DESCRIPTION
- Remove needs of `#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]` per `#[test]`
- Use `cfg(target_family = "wasm")` that indicates both wasm32&wasm64. Currently, we can use this only in tests because `cfg(target_family = "wasm")` requires Rust 1.54.