### PR TITLE
Release 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.6.0
+
+- Add `OnceCell`. (#27)
+- Support wasm64.
+
 # Version 2.5.0
 
 - Fix an issue where the future returned by `Mutex::lock_arc`/`Semaphore::acquire_arc` holds a reference to `self`. (#20, #21)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.5.0"
+version = "2.6.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.43"


### PR DESCRIPTION
Changes:
- Add `OnceCell`. (#27)
- Support wasm64 (https://github.com/smol-rs/async-lock/commit/ab4362fe811a294641595ee84e46dd5e3af0986e).
