### PR TITLE
Replace some async blocks with manual futures

### DIFF
--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -6,7 +6,8 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use crate::{Lock, Mutex};
+use crate::futures::Lock;
+use crate::Mutex;
 
 /// A counter to synchronize multiple tasks at the same time.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod once_cell;
 mod rwlock;
 mod semaphore;
 
-pub use barrier::{Barrier, BarrierWait, BarrierWaitResult};
+pub use barrier::{Barrier, BarrierWaitResult};
 pub use mutex::{Lock, LockArc, Mutex, MutexGuard, MutexGuardArc};
 pub use once_cell::OnceCell;
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ mod once_cell;
 mod rwlock;
 mod semaphore;
 
-pub use barrier::{Barrier, BarrierWaitResult};
-pub use mutex::{Mutex, MutexGuard, MutexGuardArc};
+pub use barrier::{Barrier, BarrierWait, BarrierWaitResult};
+pub use mutex::{Lock, LockArc, Mutex, MutexGuard, MutexGuardArc};
 pub use once_cell::OnceCell;
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
-pub use semaphore::{Semaphore, SemaphoreGuard, SemaphoreGuardArc};
+pub use semaphore::{Acquire, AcquireArc, Semaphore, SemaphoreGuard, SemaphoreGuardArc};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,16 @@ mod rwlock;
 mod semaphore;
 
 pub use barrier::{Barrier, BarrierWaitResult};
-pub use mutex::{Lock, LockArc, Mutex, MutexGuard, MutexGuardArc};
+pub use mutex::{Mutex, MutexGuard, MutexGuardArc};
 pub use once_cell::OnceCell;
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockUpgradableReadGuard, RwLockWriteGuard};
-pub use semaphore::{Acquire, AcquireArc, Semaphore, SemaphoreGuard, SemaphoreGuardArc};
+pub use semaphore::{Semaphore, SemaphoreGuard, SemaphoreGuardArc};
+
+pub mod futures {
+    //! Named futures for use with `async_lock` primitives.
+
+    pub use crate::barrier::BarrierWait;
+    pub use crate::mutex::{Lock, LockArc};
+    pub use crate::rwlock::{Read, UpgradableRead, Upgrade, Write};
+    pub use crate::semaphore::{Acquire, AcquireArc};
+}

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -1,10 +1,15 @@
+use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::future::Future;
+use std::marker::PhantomData;
+use std::mem;
 use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 // Note: we cannot use `target_family = "wasm"` here because it requires Rust 1.54.
 #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
@@ -12,7 +17,8 @@ use std::time::{Duration, Instant};
 
 use std::usize;
 
-use event_listener::Event;
+use event_listener::{Event, EventListener};
+use futures_lite::ready;
 
 /// An async mutex.
 ///
@@ -103,114 +109,10 @@ impl<T: ?Sized> Mutex<T> {
     /// # })
     /// ```
     #[inline]
-    pub async fn lock(&self) -> MutexGuard<'_, T> {
-        if let Some(guard) = self.try_lock() {
-            return guard;
-        }
-        self.acquire_slow().await;
-        MutexGuard(self)
-    }
-
-    /// Slow path for acquiring the mutex.
-    #[cold]
-    async fn acquire_slow(&self) {
-        // Get the current time.
-        #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
-        let start = Instant::now();
-
-        loop {
-            // Start listening for events.
-            let listener = self.lock_ops.listen();
-
-            // Try locking if nobody is being starved.
-            match self
-                .state
-                .compare_exchange(0, 1, Ordering::Acquire, Ordering::Acquire)
-                .unwrap_or_else(|x| x)
-            {
-                // Lock acquired!
-                0 => return,
-
-                // Lock is held and nobody is starved.
-                1 => {}
-
-                // Somebody is starved.
-                _ => break,
-            }
-
-            // Wait for a notification.
-            listener.await;
-
-            // Try locking if nobody is being starved.
-            match self
-                .state
-                .compare_exchange(0, 1, Ordering::Acquire, Ordering::Acquire)
-                .unwrap_or_else(|x| x)
-            {
-                // Lock acquired!
-                0 => return,
-
-                // Lock is held and nobody is starved.
-                1 => {}
-
-                // Somebody is starved.
-                _ => {
-                    // Notify the first listener in line because we probably received a
-                    // notification that was meant for a starved task.
-                    self.lock_ops.notify(1);
-                    break;
-                }
-            }
-
-            // If waiting for too long, fall back to a fairer locking strategy that will prevent
-            // newer lock operations from starving us forever.
-            #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
-            if start.elapsed() > Duration::from_micros(500) {
-                break;
-            }
-        }
-
-        // Increment the number of starved lock operations.
-        if self.state.fetch_add(2, Ordering::Release) > usize::MAX / 2 {
-            // In case of potential overflow, abort.
-            process::abort();
-        }
-
-        // Decrement the counter when exiting this function.
-        let _call = CallOnDrop(|| {
-            self.state.fetch_sub(2, Ordering::Release);
-        });
-
-        loop {
-            // Start listening for events.
-            let listener = self.lock_ops.listen();
-
-            // Try locking if nobody else is being starved.
-            match self
-                .state
-                .compare_exchange(2, 2 | 1, Ordering::Acquire, Ordering::Acquire)
-                .unwrap_or_else(|x| x)
-            {
-                // Lock acquired!
-                2 => return,
-
-                // Lock is held by someone.
-                s if s % 2 == 1 => {}
-
-                // Lock is available.
-                _ => {
-                    // Be fair: notify the first listener and then go wait in line.
-                    self.lock_ops.notify(1);
-                }
-            }
-
-            // Wait for a notification.
-            listener.await;
-
-            // Try acquiring the lock without waiting for others.
-            if self.state.fetch_or(1, Ordering::Acquire) % 2 == 0 {
-                return;
-            }
+    pub fn lock(&self) -> Lock<'_, T> {
+        Lock {
+            mutex: self,
+            acquire_slow: None,
         }
     }
 
@@ -265,14 +167,6 @@ impl<T: ?Sized> Mutex<T> {
 }
 
 impl<T: ?Sized> Mutex<T> {
-    async fn lock_arc_impl(self: Arc<Self>) -> MutexGuardArc<T> {
-        if let Some(guard) = self.try_lock_arc() {
-            return guard;
-        }
-        self.acquire_slow().await;
-        MutexGuardArc(self)
-    }
-
     /// Acquires the mutex and clones a reference to it.
     ///
     /// Returns an owned guard that releases the mutex when dropped.
@@ -290,8 +184,8 @@ impl<T: ?Sized> Mutex<T> {
     /// # })
     /// ```
     #[inline]
-    pub fn lock_arc(self: &Arc<Self>) -> impl Future<Output = MutexGuardArc<T>> {
-        self.clone().lock_arc_impl()
+    pub fn lock_arc(self: &Arc<Self>) -> LockArc<T> {
+        LockArc(LockArcInnards::Unpolled(self.clone()))
     }
 
     /// Attempts to acquire the mutex and clone a reference to it.
@@ -350,6 +244,300 @@ impl<T> From<T> for Mutex<T> {
 impl<T: Default + ?Sized> Default for Mutex<T> {
     fn default() -> Mutex<T> {
         Mutex::new(Default::default())
+    }
+}
+
+/// The future returned by [`Mutex::lock`].
+pub struct Lock<'a, T: ?Sized> {
+    /// Reference to the mutex.
+    mutex: &'a Mutex<T>,
+
+    /// The future that waits for the mutex to become available.
+    acquire_slow: Option<AcquireSlow<&'a Mutex<T>, T>>,
+}
+
+impl<'a, T: ?Sized> Unpin for Lock<'a, T> {}
+
+impl<T: ?Sized> fmt::Debug for Lock<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Lock { .. }")
+    }
+}
+
+impl<'a, T: ?Sized> Future for Lock<'a, T> {
+    type Output = MutexGuard<'a, T>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        loop {
+            match this.acquire_slow.as_mut() {
+                None => {
+                    // Try the fast path before trying to register slowly.
+                    match this.mutex.try_lock() {
+                        Some(guard) => return Poll::Ready(guard),
+                        None => {
+                            this.acquire_slow = Some(AcquireSlow::new(this.mutex));
+                        }
+                    }
+                }
+
+                Some(acquire_slow) => {
+                    // Continue registering slowly.
+                    let value = ready!(Pin::new(acquire_slow).poll(cx));
+                    return Poll::Ready(MutexGuard(value));
+                }
+            }
+        }
+    }
+}
+
+/// The future returned by [`Mutex::lock_arc`].
+pub struct LockArc<T: ?Sized>(LockArcInnards<T>);
+
+enum LockArcInnards<T: ?Sized> {
+    /// We have not tried to poll the fast path yet.
+    Unpolled(Arc<Mutex<T>>),
+
+    /// We are acquiring the mutex through the slow path.
+    AcquireSlow(AcquireSlow<Arc<Mutex<T>>, T>),
+
+    /// Empty hole to make taking easier.
+    Empty,
+}
+
+impl<T: ?Sized> Unpin for LockArc<T> {}
+
+impl<T: ?Sized> fmt::Debug for LockArc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("LockArc { .. }")
+    }
+}
+
+impl<T: ?Sized> Future for LockArc<T> {
+    type Output = MutexGuardArc<T>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        loop {
+            match mem::replace(&mut this.0, LockArcInnards::Empty) {
+                LockArcInnards::Unpolled(mutex) => {
+                    // Try the fast path before trying to register slowly.
+                    match mutex.try_lock_arc() {
+                        Some(guard) => return Poll::Ready(guard),
+                        None => {
+                            *this = LockArc(LockArcInnards::AcquireSlow(AcquireSlow::new(
+                                mutex.clone(),
+                            )));
+                        }
+                    }
+                }
+
+                LockArcInnards::AcquireSlow(mut acquire_slow) => {
+                    // Continue registering slowly.
+                    let value = match Pin::new(&mut acquire_slow).poll(cx) {
+                        Poll::Pending => {
+                            *this = LockArc(LockArcInnards::AcquireSlow(acquire_slow));
+                            return Poll::Pending;
+                        }
+                        Poll::Ready(value) => value,
+                    };
+                    return Poll::Ready(MutexGuardArc(value));
+                }
+
+                LockArcInnards::Empty => unreachable!("cannot poll an empty hole"),
+            }
+        }
+    }
+}
+
+/// Future for acquiring the mutex slowly.
+struct AcquireSlow<B: Borrow<Mutex<T>>, T: ?Sized> {
+    /// Reference to the mutex.
+    mutex: Option<B>,
+
+    /// The event listener waiting on the mutex.
+    listener: Option<EventListener>,
+
+    /// The point at which the mutex lock was started.
+    #[cfg(not(any(target_arch = "wasm32", target_os = "wasm64")))]
+    start: Option<Instant>,
+
+    /// This lock operation is starving.
+    starved: bool,
+
+    /// Capture the `T` lifetime.
+    _marker: PhantomData<T>,
+}
+
+impl<B: Borrow<Mutex<T>> + Unpin, T: ?Sized> Unpin for AcquireSlow<B, T> {}
+
+impl<T: ?Sized, B: Borrow<Mutex<T>>> AcquireSlow<B, T> {
+    /// Create a new `AcquireSlow` future.
+    #[cold]
+    fn new(mutex: B) -> Self {
+        AcquireSlow {
+            mutex: Some(mutex),
+            listener: None,
+            #[cfg(not(any(target_arch = "wasm32", target_os = "wasm64")))]
+            start: None,
+            starved: false,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Take the mutex reference out, decrementing the counter if necessary.
+    fn take_mutex(&mut self) -> Option<B> {
+        let mutex = self.mutex.take();
+
+        if self.starved {
+            if let Some(mutex) = mutex.as_ref() {
+                // Decrement this counter before we exit.
+                mutex.borrow().state.fetch_sub(2, Ordering::Release);
+            }
+        }
+
+        mutex
+    }
+}
+
+impl<T: ?Sized, B: Unpin + Borrow<Mutex<T>>> Future for AcquireSlow<B, T> {
+    type Output = B;
+
+    #[cold]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = &mut *self;
+        let start = *this.start.get_or_insert_with(Instant::now);
+        let mutex = this
+            .mutex
+            .as_ref()
+            .expect("future polled after completion")
+            .borrow();
+
+        // Only use this hot loop if we aren't currently starved.
+        if !this.starved {
+            loop {
+                // Start listening for events.
+                match this.listener.take() {
+                    None => {
+                        // Start listening for events.
+                        this.listener = Some(mutex.lock_ops.listen());
+
+                        // Try locking if nobody is being starved.
+                        match mutex
+                            .state
+                            .compare_exchange(0, 1, Ordering::Acquire, Ordering::Acquire)
+                            .unwrap_or_else(|x| x)
+                        {
+                            // Lock acquired!
+                            0 => return Poll::Ready(this.take_mutex().unwrap()),
+
+                            // Lock is held and nobody is starved.
+                            1 => {}
+
+                            // Somebody is starved.
+                            _ => break,
+                        }
+                    }
+                    Some(mut listener) => {
+                        // Wait for a notification.
+                        if Pin::new(&mut listener).poll(cx).is_pending() {
+                            // The mutex is not available.
+                            this.listener = Some(listener);
+                            return Poll::Pending;
+                        }
+
+                        // Try locking if nobody is being starved.
+                        match mutex
+                            .state
+                            .compare_exchange(0, 1, Ordering::Acquire, Ordering::Acquire)
+                            .unwrap_or_else(|x| x)
+                        {
+                            // Lock acquired!
+                            0 => return Poll::Ready(this.take_mutex().unwrap()),
+
+                            // Lock is held and nobody is starved.
+                            1 => {}
+
+                            // Somebody is starved.
+                            _ => {
+                                // Notify the first listener in line because we probably received a
+                                // notification that was meant for a starved task.
+                                mutex.lock_ops.notify(1);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // If waiting for too long, fall back to a fairer locking strategy that will prevent
+                // newer lock operations from starving us forever.
+                #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
+                if start.elapsed() > Duration::from_micros(500) {
+                    break;
+                }
+            }
+
+            // Increment the number of starved lock operations.
+            if mutex.state.fetch_add(2, Ordering::Release) > usize::MAX / 2 {
+                // In case of potential overflow, abort.
+                process::abort();
+            }
+
+            // Indicate that we are now starving and will use a fairer locking strategy.
+            this.starved = true;
+        }
+
+        // Fairer locking loop.
+        loop {
+            match this.listener.take() {
+                None => {
+                    // Start listening for events.
+                    this.listener = Some(mutex.lock_ops.listen());
+
+                    // Try locking if nobody else is being starved.
+                    match mutex
+                        .state
+                        .compare_exchange(2, 2 | 1, Ordering::Acquire, Ordering::Acquire)
+                        .unwrap_or_else(|x| x)
+                    {
+                        // Lock acquired!
+                        2 => return Poll::Ready(this.take_mutex().unwrap()),
+
+                        // Lock is held by someone.
+                        s if s % 2 == 1 => {}
+
+                        // Lock is available.
+                        _ => {
+                            // Be fair: notify the first listener and then go wait in line.
+                            mutex.lock_ops.notify(1);
+                        }
+                    }
+                }
+                Some(mut listener) => {
+                    // Wait for a notification.
+                    if Pin::new(&mut listener).poll(cx).is_pending() {
+                        // The mutex is not available.
+                        this.listener = Some(listener);
+                        return Poll::Pending;
+                    }
+
+                    // Try acquiring the lock without waiting for others.
+                    if mutex.state.fetch_or(1, Ordering::Acquire) % 2 == 0 {
+                        return Poll::Ready(this.take_mutex().unwrap());
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<T: ?Sized, B: Borrow<Mutex<T>>> Drop for AcquireSlow<B, T> {
+    fn drop(&mut self) {
+        // Make sure the starvation counter is decremented.
+        self.take_mutex();
     }
 }
 

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -409,6 +409,7 @@ impl<T: ?Sized, B: Unpin + Borrow<Mutex<T>>> Future for AcquireSlow<B, T> {
     #[cold]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = &mut *self;
+        #[cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))]
         let start = *this.start.get_or_insert_with(Instant::now);
         let mutex = this
             .mutex

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -347,7 +347,7 @@ impl<T: ?Sized> Future for LockArc<T> {
                     return Poll::Ready(MutexGuardArc(value));
                 }
 
-                LockArcInnards::Empty => unreachable!("cannot poll an empty hole"),
+                LockArcInnards::Empty => panic!("future polled after completion"),
             }
         }
     }

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -11,7 +11,8 @@ use std::task::{Context, Poll};
 use event_listener::{Event, EventListener};
 use futures_lite::ready;
 
-use crate::{Lock, Mutex, MutexGuard};
+use crate::futures::Lock;
+use crate::{Mutex, MutexGuard};
 
 const WRITER_BIT: usize = 1;
 const ONE_READER: usize = 2;
@@ -379,7 +380,7 @@ impl<T: Default + ?Sized> Default for RwLock<T> {
     }
 }
 
-/// Future returned by [`RwLock::read`].
+/// The future returned by [`RwLock::read`].
 pub struct Read<'a, T: ?Sized> {
     /// The lock that is being acquired.
     lock: &'a RwLock<T>,
@@ -453,7 +454,7 @@ impl<'a, T: ?Sized> Future for Read<'a, T> {
     }
 }
 
-/// Future returned by [`RwLock::upgradable_read`].
+/// The future returned by [`RwLock::upgradable_read`].
 pub struct UpgradableRead<'a, T: ?Sized> {
     /// The lock that is being acquired.
     lock: &'a RwLock<T>,
@@ -506,7 +507,7 @@ impl<'a, T: ?Sized> Future for UpgradableRead<'a, T> {
     }
 }
 
-/// Future returned by [`RwLock::write`].
+/// The future returned by [`RwLock::write`].
 pub struct Write<'a, T: ?Sized> {
     /// The lock that is being acquired.
     lock: &'a RwLock<T>,

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -223,7 +223,10 @@ impl Future for AcquireArc {
 
         loop {
             match this.semaphore.try_acquire_arc() {
-                Some(guard) => return Poll::Ready(guard),
+                Some(guard) => {
+                    this.listener = None;
+                    return Poll::Ready(guard);
+                }
                 None => {
                     // Wait on the listener.
                     match &mut this.listener.take() {


### PR DESCRIPTION
The goal of this PR is to resolve #4 by adding manually-implemented futures to `Mutex`, `RwLock`, `Barrier` and `Semaphore`, similar to smol-rs/async-channel#33. This aim of this PR is to improve semantics for when `poll` is the only means available to poll a future. The main downside is that is replaces the elegant `async` blocks with some more garish manual futures, but I tried to keep the semantics and ordering of logic the same throughout.

I avoided adding implementations for `OnceCell`, since with the closures and self-referential ideas it's not possible to implement without either a significant amount of hard-to-check `unsafe` code or overextensive heap allocation.

Closes #4
Closes #5