### PR TITLE
Mark `MutexGuard` with `#[clippy::has_significant_drop]`

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -536,6 +536,7 @@ impl<T: ?Sized, B: Borrow<Mutex<T>>> Drop for AcquireSlow<B, T> {
 }
 
 /// A guard that releases the mutex when dropped.
+#[clippy::has_significant_drop]
 pub struct MutexGuard<'a, T: ?Sized>(&'a Mutex<T>);
 
 unsafe impl<T: Send + ?Sized> Send for MutexGuard<'_, T> {}

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -596,6 +596,7 @@ impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
 }
 
 /// An owned guard that releases the mutex when dropped.
+#[clippy::has_significant_drop]
 pub struct MutexGuardArc<T: ?Sized>(Arc<Mutex<T>>);
 
 unsafe impl<T: Send + ?Sized> Send for MutexGuardArc<T> {}

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -604,6 +604,7 @@ impl<'a, T: ?Sized> Future for Write<'a, T> {
 }
 
 /// A guard that releases the read lock when dropped.
+#[clippy::has_significant_drop]
 pub struct RwLockReadGuard<'a, T: ?Sized>(&'a RwLock<T>);
 
 unsafe impl<T: Sync + ?Sized> Send for RwLockReadGuard<'_, T> {}
@@ -640,6 +641,7 @@ impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
 }
 
 /// A guard that releases the upgradable read lock when dropped.
+#[clippy::has_significant_drop]
 pub struct RwLockUpgradableReadGuard<'a, T: ?Sized> {
     reader: RwLockReadGuard<'a, T>,
     reserved: MutexGuard<'a, ()>,
@@ -851,6 +853,7 @@ impl<T: ?Sized> Drop for RwLockWriteGuardInner<'_, T> {
 }
 
 /// A guard that releases the write lock when dropped.
+#[clippy::has_significant_drop]
 pub struct RwLockWriteGuard<'a, T: ?Sized> {
     writer: RwLockWriteGuardInner<'a, T>,
     reserved: MutexGuard<'a, ()>,

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -244,6 +244,7 @@ impl Future for AcquireArc {
 }
 
 /// A guard that releases the acquired permit.
+#[clippy::has_significant_drop]
 #[derive(Debug)]
 pub struct SemaphoreGuard<'a>(&'a Semaphore);
 
@@ -255,6 +256,7 @@ impl Drop for SemaphoreGuard<'_> {
 }
 
 /// An owned guard that releases the acquired permit.
+#[clippy::has_significant_drop]
 #[derive(Debug)]
 pub struct SemaphoreGuardArc(Arc<Semaphore>);
 


### PR DESCRIPTION
`#[clippy::has_significant_drop]` tells that a structure should be considered when evaluating some lints. Examples of such behavior are the existent `clippy::significant_drop_in_scrutinee` and the soon-to-be-finished https://github.com/rust-lang/rust-clippy/issues/9399.