### PR TITLE
Release version 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 2.7.0
+
+- Replace some `async` blocks with manual futures (#34)
+- Remove our dependency on `futures-lite` (#36)
+- Mark guard types with `#[clippy::has_significant_drop]` (#37)
+
 # Version 2.6.0
 
 - Add `OnceCell`. (#27)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.6.0"
+version = "2.7.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.48"


### PR DESCRIPTION
- Replace some `async` blocks with manual futures (#34)
- Remove our dependency on `futures-lite` (#36)
- Mark guard types with `#[clippy::has_significant_drop]` (#37)