### PR TITLE
feat: Support blocking and non-blocking operations on the same locks

### DIFF
--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -164,7 +164,7 @@ impl BarrierWait<'_> {
     fn wait(mut self) -> BarrierWaitResult {
         match self.poll_with_strategy(&mut Blocking, &mut ()) {
             Poll::Ready(result) => result,
-            Poll::Pending => panic!("future did not complete"),
+            Poll::Pending => unreachable!(),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@
 
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
+use event_listener::EventListener;
+use std::{future::Future, marker::PhantomData};
+
 /// Simple macro to extract the value of `Poll` or return `Pending`.
 ///
 /// TODO: Drop in favor of `core::task::ready`, once MSRV is bumped to 1.64.
@@ -42,4 +45,62 @@ pub mod futures {
     pub use crate::mutex::{Lock, LockArc};
     pub use crate::rwlock::{Read, UpgradableRead, Upgrade, Write};
     pub use crate::semaphore::{Acquire, AcquireArc};
+}
+
+/// The strategy for polling an `event_listener::EventListener`.
+trait Strategy {
+    /// The future that can be polled to wait on the listener.
+    type Fut: Future<Output = ()>;
+
+    /// The context for a poll.
+    type Context: ?Sized;
+
+    /// Polls the event listener.
+    fn poll(&mut self, cx: &mut Self::Context, evl: EventListener) -> Result<(), EventListener>;
+
+    /// A future that polls the event listener.
+    fn future(&mut self, evl: EventListener) -> Self::Fut;
+}
+
+/// The strategy for blocking the current thread on an `EventListener`.
+struct Blocking;
+
+impl Strategy for Blocking {
+    type Fut = std::future::Ready<()>;
+    type Context = ();
+
+    fn poll(&mut self, _cx: &mut Self::Context, evl: EventListener) -> Result<(), EventListener> {
+        evl.wait();
+        Ok(())
+    }
+
+    fn future(&mut self, evl: EventListener) -> Self::Fut {
+        evl.wait();
+        std::future::ready(())
+    }
+}
+
+/// The strategy for polling an `EventListener` in an async context.
+#[derive(Default)]
+struct NonBlocking<'a>(PhantomData<&'a mut ()>);
+
+impl<'a> Strategy for NonBlocking<'a> {
+    type Fut = EventListener;
+    type Context = std::task::Context<'a>;
+
+    fn poll(
+        &mut self,
+        cx: &mut Self::Context,
+        mut evl: EventListener,
+    ) -> Result<(), EventListener> {
+        use std::task::Poll;
+        match std::pin::Pin::new(&mut evl).poll(cx) {
+            Poll::Ready(()) => Ok(()),
+            Poll::Pending => Err(evl),
+        }
+    }
+
+    fn future(&mut self, evl: EventListener) -> Self::Fut {
+        evl
+    }
 }

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -44,3 +44,40 @@ fn smoke() {
         }
     });
 }
+
+#[test]
+fn smoke_blocking() {
+    const N: usize = 10;
+
+    let barrier = Arc::new(Barrier::new(N));
+
+    for _ in 0..10 {
+        let (tx, rx) = async_channel::unbounded();
+
+        for _ in 0..N - 1 {
+            let c = barrier.clone();
+            let tx = tx.clone();
+
+            thread::spawn(move || {
+                let res = c.wait_blocking();
+                tx.send_blocking(res.is_leader()).unwrap();
+            });
+        }
+
+        // At this point, all spawned threads should be blocked,
+        // so we shouldn't get anything from the cahnnel.
+        let res = rx.try_recv();
+        assert!(res.is_err());
+
+        let mut leader_found = barrier.wait_blocking().is_leader();
+
+        // Now, the barrier is cleared and we should get data.
+        for _ in 0..N - 1 {
+            if rx.recv_blocking().unwrap() {
+                assert!(!leader_found);
+                leader_found = true;
+            }
+        }
+        assert!(leader_found);
+    }
+}

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -21,6 +21,13 @@ fn smoke() {
 }
 
 #[test]
+fn smoke_blocking() {
+    let m = Mutex::new(());
+    drop(m.lock_blocking());
+    drop(m.lock_blocking());
+}
+
+#[test]
 fn try_lock() {
     let m = Mutex::new(());
     *m.try_lock().unwrap() = ();


### PR DESCRIPTION
This PR adds support for blocking and non-blocking operations on the same mutex. It uses a similar strategy to smol-rs/async-channel#47, where a `Strategy` is used to determine whether a lock should be polled or blocked on.

Inteded to supersede #25 