### PR TITLE
don't busy wait in SemaphoreGuard::acquire_arc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ event-listener = "2.5.1"
 async-channel = "1.5.0"
 fastrand = "1.4.0"
 futures-lite = "1.12.0"
+waker-fn = "1.1.0"
 
 [target.'cfg(any(target_arch = "wasm32", target_arch = "wasm64"))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -421,9 +421,9 @@ impl<T: ?Sized, B: Unpin + Borrow<Mutex<T>>> Future for AcquireSlow<B, T> {
             loop {
                 // Start listening for events.
                 match &mut this.listener {
-                    listener @ None => {
+                    None => {
                         // Start listening for events.
-                        *listener = Some(mutex.lock_ops.listen());
+                        this.listener = Some(mutex.lock_ops.listen());
 
                         // Try locking if nobody is being starved.
                         match mutex
@@ -490,9 +490,9 @@ impl<T: ?Sized, B: Unpin + Borrow<Mutex<T>>> Future for AcquireSlow<B, T> {
         // Fairer locking loop.
         loop {
             match &mut this.listener {
-                listener @ None => {
+                None => {
                     // Start listening for events.
-                    *listener = Some(mutex.lock_ops.listen());
+                    this.listener = Some(mutex.lock_ops.listen());
 
                     // Try locking if nobody else is being starved.
                     match mutex

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -426,8 +426,8 @@ impl<'a, T: ?Sized> Future for Read<'a, T> {
             } else {
                 // Start listening for "no writer" events.
                 let load_ordering = match &mut this.listener {
-                    listener @ None => {
-                        *listener = Some(this.lock.no_writer.listen());
+                    None => {
+                        this.listener = Some(this.lock.no_writer.listen());
 
                         // Make sure there really is no writer.
                         Ordering::SeqCst
@@ -823,9 +823,9 @@ impl<'a, T: ?Sized> Future for Upgrade<'a, T> {
 
             // If there are readers, wait for them to finish.
             match &mut this.listener {
-                listener @ None => {
+                None => {
                     // Start listening for "no readers" events.
-                    *listener = Some(guard.writer.0.no_readers.listen());
+                    this.listener = Some(guard.writer.0.no_readers.listen());
                 }
 
                 Some(ref mut listener) => {

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -228,7 +228,7 @@ impl Future for AcquireArc {
                 }
                 None => {
                     // Wait on the listener.
-                    match &mut this.listener.take() {
+                    match &mut this.listener {
                         listener @ None => {
                             *listener = Some(this.semaphore.event.listen());
                         }

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -183,8 +183,8 @@ impl<'a> Future for Acquire<'a> {
                 None => {
                     // Wait on the listener.
                     match &mut this.listener {
-                        listener @ None => {
-                            *listener = Some(this.semaphore.event.listen());
+                        None => {
+                            this.listener = Some(this.semaphore.event.listen());
                         }
                         Some(ref mut listener) => {
                             ready!(Pin::new(listener).poll(cx));
@@ -229,8 +229,8 @@ impl Future for AcquireArc {
                 None => {
                     // Wait on the listener.
                     match &mut this.listener {
-                        listener @ None => {
-                            *listener = Some(this.semaphore.event.listen());
+                        None => {
+                            this.listener = Some(this.semaphore.event.listen());
                         }
                         Some(ref mut listener) => {
                             ready!(Pin::new(listener).poll(cx));

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,23 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::Context;
+
+use futures_lite::prelude::*;
+use waker_fn::waker_fn;
+
+pub fn check_yields_when_contended<G>(
+    contending_guard: G,
+    mut acquire_future: impl Future + Unpin,
+) {
+    let was_woken = Arc::new(AtomicBool::new(false));
+    let waker = {
+        let was_woken = Arc::clone(&was_woken);
+        waker_fn(move || was_woken.store(true, Ordering::SeqCst))
+    };
+    let mut cx = Context::from_waker(&waker);
+
+    assert!(acquire_future.poll(&mut cx).is_pending());
+    drop(contending_guard);
+    assert!(was_woken.load(Ordering::SeqCst));
+    assert!(acquire_future.poll(&mut cx).is_ready());
+}

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -1,9 +1,13 @@
+mod common;
+
 use std::sync::Arc;
 #[cfg(not(target_family = "wasm"))]
 use std::thread;
 
 use async_lock::Mutex;
 use futures_lite::future;
+
+use common::check_yields_when_contended;
 
 #[cfg(target_family = "wasm")]
 use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -79,4 +83,13 @@ fn lifetime() {
         let mutex = Arc::new(Mutex::new(0i32));
         mutex.lock_arc()
     };
+}
+
+#[test]
+fn yields_when_contended() {
+    let m = Mutex::new(());
+    check_yields_when_contended(m.try_lock().unwrap(), m.lock());
+
+    let m = Arc::new(m);
+    check_yields_when_contended(m.try_lock_arc().unwrap(), m.lock_arc());
 }

--- a/tests/semaphore.rs
+++ b/tests/semaphore.rs
@@ -1,5 +1,9 @@
+mod common;
+
 use std::sync::{mpsc, Arc};
 use std::thread;
+
+use common::check_yields_when_contended;
 
 use async_lock::Semaphore;
 use futures_lite::future;
@@ -91,4 +95,13 @@ fn lifetime() {
         let mutex = Arc::new(Semaphore::new(2));
         mutex.acquire_arc()
     };
+}
+
+#[test]
+fn yields_when_contended() {
+    let s = Semaphore::new(1);
+    check_yields_when_contended(s.try_acquire().unwrap(), s.acquire());
+
+    let s = Arc::new(s);
+    check_yields_when_contended(s.try_acquire_arc().unwrap(), s.acquire_arc());
 }


### PR DESCRIPTION
Fixes #41

I also added a test for this for each of `Mutex`/`RwLock`/`Semaphore`. The existing tests almost all use different threads when tasks contend for locks so they wouldn't catch this.