### PR TITLE
v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Version 3.0.0
+
+- **Breaking:** Add an enabled-by-default `std` feature that allows using this crate without the standard library. (#43)
+- Support blocking and non-blocking operations on the same locks. (#56)
+- Switch to a more efficient event notification mechanism. (#43)
+
 # Version 2.8.0
 
 - Fix a bug where the `SemaphoreGuard::acquire_arc` future would busy wait under certain conditions (#42).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v2.x.y" git tag
-version = "2.8.0"
+# - Create "v3.x.y" git tag
+version = "3.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- **Breaking:** Add an enabled-by-default `std` feature that allows using this crate without the standard library. (#43)
- Support blocking and non-blocking operations on the same locks. (#56)
- Switch to a more efficient event notification mechanism. (#43)