### PR TITLE
v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.1.0
+
+- Add a `Default` implementation for `OnceCell` (#63).
+
 # Version 3.0.0
 
 - **Breaking:** Add an enabled-by-default `std` feature that allows using this crate without the standard library. (#43)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- Add a `Default` implementation for `OnceCell` (#63).
- Bump versions of dependencies (#60, #61).
