### PR TITLE
v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.1.2
+
+- Bump `event-listener` to version v4.0.0. (#69)
+
 # Version 3.1.1
 
 - Add a note to the documentation comparing this crate against `libstd`'s locks. (#58)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.1.1"
+version = "3.1.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- Bump `event-listener` to version v4.0.0. (#69)
