### PR TITLE
v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 3.2.0
+
+- Add missing methods for blocking on locking with types wrapped in `Arc` (#71).
+
 # Version 3.1.2
 
 - Bump `event-listener` to version v4.0.0. (#69)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.1.2"
+version = "3.2.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.59"


### PR DESCRIPTION
- Add missing methods for blocking on locking with types wrapped in `Arc` (#71).
