### PR TITLE
v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 3.3.0
+
+- Add a `forget()` method for semaphore guards. (#73)
+- Increase MSRV to v1.60. (#75)
+
 # Version 3.2.0
 
 - Add missing methods for blocking on locking with types wrapped in `Arc` (#71).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-lock"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v3.x.y" git tag
-version = "3.2.0"
+version = "3.3.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
- Add a `forget()` method for semaphore guards. (#73)
- Increase MSRV to v1.60. (#75)
