### PR TITLE
Remove redundant import

### DIFF
--- a/tests/rwlock.rs
+++ b/tests/rwlock.rs
@@ -8,8 +8,6 @@ use common::check_yields_when_contended;
 #[cfg(not(target_family = "wasm"))]
 use futures_lite::prelude::*;
 #[cfg(not(target_family = "wasm"))]
-use std::future::Future;
-#[cfg(not(target_family = "wasm"))]
 use std::thread;
 
 use futures_lite::future;


### PR DESCRIPTION
```
error: the item `Future` is imported redundantly
  --> tests/rwlock.rs:11:5
   |
9  | use futures_lite::prelude::*;
   |     ------------------------ the item `Future` is already imported here
10 | #[cfg(not(target_family = "wasm"))]
11 | use std::future::Future;
   |     ^^^^^^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`
```