### PR TITLE
Replace async-channel with flume

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ default = ["std"]
 std = ["event-listener/std", "event-listener-strategy/std"]
 
 [dev-dependencies]
-async-channel = "2.2.0"
 fastrand = "2.0.0"
+flume = "0.11.0"
 futures-lite = "2.0.0"
 waker-fn = "1.1.0"
 

--- a/src/barrier.rs
+++ b/src/barrier.rs
@@ -123,6 +123,8 @@ impl Barrier {
     ///         println!("after wait");
     ///     });
     /// }
+    /// # // Wait for threads to stop.
+    /// # std::thread::sleep(std::time::Duration::from_secs(1));
     /// ```
     #[cfg(all(feature = "std", not(target_family = "wasm")))]
     pub fn wait_blocking(&self) -> BarrierWaitResult {

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -12,7 +12,7 @@ fn smoke() {
         let barrier = Arc::new(Barrier::new(N));
 
         for _ in 0..10 {
-            let (tx, rx) = async_channel::unbounded();
+            let (tx, rx) = flume::unbounded();
 
             for _ in 0..N - 1 {
                 let c = barrier.clone();
@@ -21,7 +21,7 @@ fn smoke() {
                 thread::spawn(move || {
                     future::block_on(async move {
                         let res = c.wait().await;
-                        tx.send(res.is_leader()).await.unwrap();
+                        tx.send_async(res.is_leader()).await.unwrap();
                     })
                 });
             }
@@ -35,7 +35,7 @@ fn smoke() {
 
             // Now, the barrier is cleared and we should get data.
             for _ in 0..N - 1 {
-                if rx.recv().await.unwrap() {
+                if rx.recv_async().await.unwrap() {
                     assert!(!leader_found);
                     leader_found = true;
                 }
@@ -55,7 +55,7 @@ fn smoke_blocking() {
         let barrier = Arc::new(Barrier::new(N));
 
         for _ in 0..10 {
-            let (tx, rx) = async_channel::unbounded();
+            let (tx, rx) = flume::unbounded();
 
             for _ in 0..N - 1 {
                 let c = barrier.clone();
@@ -63,7 +63,7 @@ fn smoke_blocking() {
 
                 thread::spawn(move || {
                     let res = c.wait_blocking();
-                    tx.send_blocking(res.is_leader()).unwrap();
+                    tx.send(res.is_leader()).unwrap();
                 });
             }
 
@@ -76,7 +76,7 @@ fn smoke_blocking() {
 
             // Now, the barrier is cleared and we should get data.
             for _ in 0..N - 1 {
-                if rx.recv().await.unwrap() {
+                if rx.recv_async().await.unwrap() {
                     assert!(!leader_found);
                     leader_found = true;
                 }

--- a/tests/barrier.rs
+++ b/tests/barrier.rs
@@ -5,6 +5,7 @@ use async_lock::Barrier;
 use futures_lite::future;
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn smoke() {
     future::block_on(async move {
         const N: usize = 10;

--- a/tests/mutex.rs
+++ b/tests/mutex.rs
@@ -63,7 +63,7 @@ fn get_mut() {
 #[test]
 fn contention() {
     future::block_on(async {
-        let (tx, rx) = async_channel::unbounded();
+        let (tx, rx) = flume::unbounded();
 
         let tx = Arc::new(tx);
         let mutex = Arc::new(Mutex::new(0i32));
@@ -77,14 +77,14 @@ fn contention() {
                 future::block_on(async move {
                     let mut lock = mutex.lock().await;
                     *lock += 1;
-                    tx.send(()).await.unwrap();
+                    tx.send_async(()).await.unwrap();
                     drop(lock);
                 })
             });
         }
 
         for _ in 0..num_tasks {
-            rx.recv().await.unwrap();
+            rx.recv_async().await.unwrap();
         }
 
         let lock = mutex.lock().await;


### PR DESCRIPTION
This commit replaces async-channel in some tests with flume. It appears
that async-channel doesn't work under MIRI but flume does, so we can
work around this for now by replacing it with flume.

cc https://github.com/smol-rs/async-channel/issues/85
