### PR TITLE
Draft : add an async implementation of RefCell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,11 @@ fastrand = "2.0.0"
 flume = "0.11.0"
 futures-lite = "2.0.0"
 waker-fn = "1.1.0"
+async-std = "1.0"
+
+[patch.crates-io]
+# use local async-lock as dependency of async-std for dev-dependencies, instead of published one
+async-lock = { path = "." }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! * [`Barrier`] - enables tasks to synchronize all together at the same time.
 //! * [`Mutex`] - a mutual exclusion lock.
+//! * [`RefCell`] - a single thread reader-writer lock, allowing any number of readers or a single writer.
 //! * [`RwLock`] - a reader-writer lock, allowing any number of readers or a single writer.
 //! * [`Semaphore`] - limits the number of concurrent operations.
 //!
@@ -90,12 +91,14 @@ macro_rules! const_fn {
 mod barrier;
 mod mutex;
 mod once_cell;
+mod refcell;
 mod rwlock;
 mod semaphore;
 
 pub use barrier::{Barrier, BarrierWaitResult};
 pub use mutex::{Mutex, MutexGuard, MutexGuardArc};
 pub use once_cell::OnceCell;
+pub use refcell::RefCell;
 pub use rwlock::{
     RwLock, RwLockReadGuard, RwLockReadGuardArc, RwLockUpgradableReadGuard,
     RwLockUpgradableReadGuardArc, RwLockWriteGuard, RwLockWriteGuardArc,

--- a/src/refcell.rs
+++ b/src/refcell.rs
@@ -1,0 +1,262 @@
+//! source of inspiration :
+//! <https://rust-lang.github.io/async-book/02_execution/03_wakeups.html>
+
+mod raw;
+
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    future::Future,
+    ops::{Deref, DerefMut},
+    ptr::NonNull,
+    task::Poll,
+};
+use raw::{RawBorrow, RawBorrowMut, RawRefCell};
+
+/// A single thread async mutable memory location.
+///
+/// This type of lock allows multiple readers or one writer at any point in time.
+/// It's can be used with [`LocalExecutor`].
+///
+/// [`LocalExecutor`]: https://docs.rs/async-executor/latest/async_executor/struct.LocalExecutor.html
+pub struct RefCell<T: ?Sized> {
+    //borrow: Cell<BorrowFlag>,
+    raw: RawRefCell,
+    value: UnsafeCell<T>,
+}
+impl<T> RefCell<T> {
+    /// Create a new RefCell.
+    pub fn new(value: T) -> RefCell<T> {
+        Self {
+            raw: RawRefCell::new(),
+            //borrow: Cell::new(BorrowFlag::Available),
+            value: UnsafeCell::new(value),
+        }
+    }
+}
+
+impl<T: ?Sized> RefCell<T> {
+    //TODO:
+    // pub fn into_inner(self) -> T {
+    //     self.value.into_inner()
+    // }
+
+    //pub fn replace(&self, t: T) -> T {}
+    //pub fn replace_with<F>(&self, f: F) -> T
+    //pub fn swap(&self, other: &RefCell<T>)
+
+    /// Acquire a borrow on the wrapped value.
+    ///
+    /// This wait the end of the current borrow_mut.
+    ///
+    /// Returns a guard that releases the lock when dropped.
+    pub fn borrow(&self) -> Borrow<'_, T> {
+        Borrow::new(self.raw.borrow(), self.value.get())
+    }
+
+    /// Tried to acquire a borrow on the wrapped value.
+    ///
+    /// Return `None` instead of wait if a borrow_mut is in progress.
+    pub fn try_borrow(&self) -> Option<Ref<'_, T>> {
+        if self.raw.try_borrow() {
+            Some(Ref {
+                value: self.value.get(),
+                lock: &self.raw,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Mutably borrows the wrapped value.
+    /// `await` if the value is currently borrowed. For non `async` variant, use [`Self::try_borrow_mut`].
+    /// TODO:
+    pub fn borrow_mut(&self) -> BorrowMut<'_, T> {
+        BorrowMut::new(self.raw.borrow_mut(), self.value.get())
+    }
+
+    /// Tried to acquire a borrow on the wrapped value.
+    ///
+    /// Return `None` instead of wait if a borrow_mut is in progress.
+    pub fn try_borrow_mut(&self) -> Option<RefMut<'_, T>> {
+        if self.raw.try_borrow_mut() {
+            Some(RefMut {
+                value: self.value.get(),
+                lock: &self.raw,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T: fmt::Debug + ?Sized> fmt::Debug for RefCell<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct Locked;
+        impl fmt::Debug for Locked {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("<locked>")
+            }
+        }
+
+        match self.try_borrow() {
+            None => f.debug_struct("RefCell").field("value", &Locked).finish(),
+            Some(guard) => f.debug_struct("RefCell").field("value", &&*guard).finish(),
+        }
+    }
+}
+pub struct Borrow<'b, T: ?Sized> {
+    value: NonNull<T>,
+    raw: RawBorrow<'b>, // &'b
+                        //waker: Waker,
+}
+
+impl<'x, T: ?Sized> Borrow<'x, T> {
+    fn new(raw: RawBorrow<'x>, value: *mut T) -> Self {
+        let value = unsafe { NonNull::new_unchecked(value) };
+        Self { value, raw }
+    }
+}
+
+impl<'b, T: ?Sized + 'b> Future for Borrow<'b, T> {
+    type Output = Ref<'b, T>;
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        if self.raw.try_borrow() {
+            Poll::Ready(Ref::<T> {
+                lock: self.raw.lock,
+                value: self.value.as_ptr(),
+            })
+        } else {
+            // set state waiting ?
+            self.raw.lock.borrow_wake(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for Borrow<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Borrow { .. }")
+    }
+}
+pub struct BorrowMut<'b, T: ?Sized> {
+    value: NonNull<T>,
+    raw: RawBorrowMut<'b>, // &'b
+                           //waker: Waker,
+}
+
+impl<'x, T: ?Sized> BorrowMut<'x, T> {
+    fn new(raw: RawBorrowMut<'x>, value: *mut T) -> Self {
+        let value = unsafe { NonNull::new_unchecked(value) };
+        Self { value, raw }
+    }
+}
+
+impl<'b, T: ?Sized + 'b> Future for BorrowMut<'b, T> {
+    type Output = RefMut<'b, T>;
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        if self.raw.try_borrow_mut() {
+            Poll::Ready(RefMut::<T> {
+                lock: self.raw.lock,
+                value: self.value.as_ptr(),
+            })
+        } else {
+            // set state waiting ?
+            self.raw.lock.borrow_mut_wake(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for BorrowMut<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("BorrowMut { .. }")
+    }
+}
+
+/// Wraps a borrowed reference to a value in a `RefCell` box.
+/// A wrapper type for an immutably borrowed value from a `RefCell<T>`.
+///
+/// See the [module-level documentation](self) for more.
+pub struct Ref<'a, T: ?Sized + 'a> {
+    lock: &'a RawRefCell,
+    value: *const T,
+}
+
+impl<T: ?Sized> Drop for Ref<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        self.lock.borrow_unlock();
+    }
+}
+impl<T: fmt::Debug + ?Sized> fmt::Debug for Ref<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+impl<T: fmt::Display + ?Sized> fmt::Display for Ref<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+impl<T: ?Sized> Deref for Ref<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.value }
+    }
+}
+
+/// A wrapper type for a mutably borrowed value from a RefCell<T>.
+///
+/// See the [module-level documentation](self) for more.
+pub struct RefMut<'a, T: ?Sized + 'a> {
+    lock: &'a RawRefCell,
+    value: *mut T,
+}
+
+impl<T: ?Sized> Drop for RefMut<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        self.lock.borrow_mut_unlock();
+    }
+}
+impl<T: fmt::Debug + ?Sized> fmt::Debug for RefMut<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+impl<T: fmt::Display + ?Sized> fmt::Display for RefMut<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+impl<T: ?Sized> Deref for RefMut<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        unsafe { &*self.value }
+    }
+}
+impl<T: ?Sized> DerefMut for RefMut<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.value }
+    }
+}

--- a/src/refcell/raw.rs
+++ b/src/refcell/raw.rs
@@ -1,0 +1,152 @@
+use core::{
+    cell::{Cell, RefCell},
+    task::Waker,
+};
+use std::collections::VecDeque;
+
+const BORROW_MUT_BIT: usize = 1;
+const ONE_BORROW: usize = 2;
+
+pub(super) struct RawRefCell {
+    /// Event triggered when the last borrow is dropped.
+    borrow_wakes: RefCell<VecDeque<Waker>>,
+
+    /// Event triggered when the borrow_mut is dropped.
+    borrow_mut_wakes: RefCell<VecDeque<Waker>>,
+
+    /// Current state of the lock.
+    ///
+    /// The least significant bit (`WRITER_BIT`) is set to 1 when a writer is holding the lock or
+    /// trying to acquire it.
+    ///
+    /// The upper bits contain the number of currently active borrows. Each active reader
+    /// increments the state by `ONE_BORROW`.
+    state: Cell<usize>,
+}
+
+impl RawRefCell {
+    pub(super) const fn new() -> Self {
+        Self {
+            borrow_wakes: RefCell::new(VecDeque::new()),
+            borrow_mut_wakes: RefCell::new(VecDeque::new()),
+            state: Cell::new(0),
+        }
+    }
+
+    pub(super) fn borrow(&self) -> RawBorrow<'_> {
+        RawBorrow { lock: self }
+    }
+
+    pub(super) fn borrow_wake(&self, waker: Waker) {
+        self.borrow_wakes.borrow_mut().push_back(waker);
+    }
+
+    pub(super) fn try_borrow(&self) -> bool {
+        let state = self.state.get();
+
+        // If there's a mutable borrow holding the lock or attempting to acquire it, we cannot acquire
+        // a read lock here.
+        if state & BORROW_MUT_BIT != 0 {
+            return false;
+        }
+
+        // Make sure the number of borrows doesn't overflow.
+        if state > isize::MAX as usize {
+            crate::abort();
+        }
+
+        // Increment the number of readers.
+        // TODO ? ok if self.state.update(|val| val + ONE_BORROW ) == state + ONE_BORROW;
+        self.state.set(state + ONE_BORROW);
+
+        true
+    }
+
+    pub(super) fn borrow_unlock(&self) {
+        // Decrement the number of borrows.
+        let state = self.state.get();
+        self.state.set(state - ONE_BORROW);
+
+        if self.state.get() == 0 {
+            // If this was the last reader, wake up the next borrow the "no borrows" event.
+            if let Some(borrow_mut_wake) = self.borrow_mut_wakes.borrow_mut().pop_front() {
+                borrow_mut_wake.wake();
+            }
+        }
+    }
+
+    pub(super) fn borrow_mut(&self) -> RawBorrowMut<'_> {
+        RawBorrowMut { lock: self }
+    }
+
+    pub(super) fn borrow_mut_wake(&self, waker: Waker) {
+        self.borrow_mut_wakes.borrow_mut().push_back(waker);
+    }
+
+    pub(super) fn try_borrow_mut(&self) -> bool {
+        let state = self.state.get();
+
+        // If there's a mutable borrow holding the lock or attempting to acquire it, we cannot acquire
+        // a borrow_mut lock here.
+        if state & BORROW_MUT_BIT != 0 {
+            return false;
+        }
+
+        // If there's at least one simple borrow, we cannot acquire
+        // a borrow_mut lock here.
+        if state & !BORROW_MUT_BIT != 0 {
+            return false;
+        }
+
+        // Increment the number of readers.
+        // TODO ? ok if self.state.update(|val| val & BORROW_MUT_BIT ) == BORROW_MUT_BIT;
+        self.state.set(BORROW_MUT_BIT);
+
+        true
+    }
+
+    pub(super) fn borrow_mut_unlock(&self) {
+        if let Some(borrow_mut_wake) = self.borrow_mut_wakes.borrow_mut().pop_front() {
+            // If there is a waiting borrow_mut, wake up
+            borrow_mut_wake.wake();
+        } else {
+            // Only remove Borrow mut bit, if there is no other task waiting for it.
+            let new_state = self.state.get() & !BORROW_MUT_BIT;
+            self.state.set(new_state);
+            // else, wakeup borrow_wake
+            let mut borrow_wakes = self.borrow_wakes.borrow_mut();
+
+            borrow_wakes
+                .drain(0..)
+                .for_each(|waiting_borrow| waiting_borrow.wake());
+        }
+    }
+}
+
+pub(super) struct RawBorrow<'a> {
+    // The lock that is being acquired.
+    pub(super) lock: &'a RawRefCell,
+    // ??? // Making this type `!Unpin` enables future optimizations.
+    // #[pin]
+    // _pin: PhantomPinned
+}
+
+impl RawBorrow<'_> {
+    pub fn try_borrow(&self) -> bool {
+        self.lock.try_borrow()
+    }
+}
+
+pub(super) struct RawBorrowMut<'a> {
+    // The lock that is being acquired.
+    pub(super) lock: &'a RawRefCell,
+    // ??? // Making this type `!Unpin` enables future optimizations.
+    // #[pin]
+    // _pin: PhantomPinned
+}
+
+impl RawBorrowMut<'_> {
+    pub fn try_borrow_mut(&self) -> bool {
+        self.lock.try_borrow_mut()
+    }
+}

--- a/tests/refcell.rs
+++ b/tests/refcell.rs
@@ -1,0 +1,51 @@
+use async_lock::RefCell;
+use async_std::task::sleep;
+use futures_lite::future;
+use std::time::Duration;
+
+#[test]
+fn test_refcell() {
+    let vec = RefCell::new(Vec::new());
+
+    // insert entry in vec
+    let insert_fut = async {
+        let mut idx = 1;
+        loop {
+            {
+                let mut vec = vec.borrow_mut().await;
+                let new_val = (((idx + 10) * 4) + idx + 3) / 3;
+                sleep(Duration::from_micros(500)).await;
+                println!("Insert new val :{new_val}");
+                vec.push(new_val);
+            }
+            sleep(Duration::from_secs(2)).await;
+            idx += 1;
+            if idx == 10 {
+                sleep(Duration::from_secs(2)).await;
+                break;
+            }
+        }
+
+        sleep(Duration::from_secs(2)).await;
+        vec.borrow_mut().await.clear();
+    };
+
+    // print the content of vec
+    let print_fut = async {
+        sleep(Duration::from_micros(100)).await;
+        loop {
+            {
+                let vec = vec.borrow().await;
+                if vec.is_empty() {
+                    return;
+                }
+                println!("Vec :");
+                vec.iter()
+                    .enumerate()
+                    .for_each(|(idx, val)| println!("\t{idx}: {val}"));
+            }
+            sleep(Duration::from_micros(1500)).await;
+        }
+    };
+    future::block_on(future::zip(insert_fut, print_fut));
+}


### PR DESCRIPTION
_This is a draft to get comment._

During my experience of implementing puffin server on only one thread with async management (https://github.com/gwen-lg/puffin/commits/async_client_connecting_local/),
I was confronted with the risk of problem with usage of await during borrow of RefCell, so I have search for an async version of RefCell, but not found, so I have tried to implement myself.
As I was in a single thread context (with LocalExecutor), use RwLock seems not the most adapted.

I have in progress test to use it here : https://github.com/gwen-lg/puffin/commit/934209e0acaf1bf7724972fe78cb8035be8fdab4

Are you interested to add a RefCell in async-lock ?
If yes, have you some remark on the work ? On how to transform the PoC into "ready to include" work ?