### PR TITLE
ci: Use reusable workflows for fmt and security_audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,16 @@ defaults:
     shell: bash
 
 jobs:
+  fmt:
+    uses: smol-rs/.github/.github/workflows/fmt.yml@main
+  security_audit:
+    uses: smol-rs/.github/.github/workflows/security_audit.yml@main
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+    secrets: inherit
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -90,14 +100,6 @@ jobs:
           RUSTFLAGS: "--cfg=loom"
           LOOM_MAX_PREEMPTIONS: 4
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo fmt --all --check
-
   miri:
     runs-on: ubuntu-latest
     steps:
@@ -117,19 +119,3 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - run: cargo doc --all --all-features
-
-  security_audit:
-    permissions:
-      checks: write
-      contents: read
-      issues: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      # rustsec/audit-check used to do this automatically
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-      # https://github.com/rustsec/audit-check/issues/2
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -687,7 +687,7 @@ impl<T> OnceCell<T> {
         /// `UNINITIALIZED` and that the next listener is notified.
         struct Guard<'a, T>(&'a OnceCell<T>);
 
-        impl<'a, T> Drop for Guard<'a, T> {
+        impl<T> Drop for Guard<'_, T> {
             fn drop(&mut self) {
                 self.0
                     .state

--- a/src/rwlock.rs
+++ b/src/rwlock.rs
@@ -848,7 +848,7 @@ pub struct RwLockUpgradableReadGuard<'a, T: ?Sized> {
     value: *mut T,
 }
 
-impl<'a, T: ?Sized> Drop for RwLockUpgradableReadGuard<'a, T> {
+impl<T: ?Sized> Drop for RwLockUpgradableReadGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         // SAFETY: we are dropping an upgradable read guard.
@@ -1219,7 +1219,7 @@ pub struct RwLockWriteGuard<'a, T: ?Sized> {
 unsafe impl<T: Send + ?Sized> Send for RwLockWriteGuard<'_, T> {}
 unsafe impl<T: Sync + ?Sized> Sync for RwLockWriteGuard<'_, T> {}
 
-impl<'a, T: ?Sized> Drop for RwLockWriteGuard<'a, T> {
+impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
     #[inline]
     fn drop(&mut self) {
         // SAFETY: we are dropping a write lock

--- a/src/rwlock/futures.rs
+++ b/src/rwlock/futures.rs
@@ -104,7 +104,7 @@ impl<T> fmt::Debug for ReadArc<'_, T> {
     }
 }
 
-impl<'a, T> EventListenerFuture for ReadArcInner<'a, T> {
+impl<T> EventListenerFuture for ReadArcInner<'_, T> {
     type Output = RwLockReadGuardArc<T>;
 
     #[inline]
@@ -216,7 +216,7 @@ impl<T: ?Sized> fmt::Debug for UpgradableReadArc<'_, T> {
     }
 }
 
-impl<'a, T: ?Sized> EventListenerFuture for UpgradableReadArcInner<'a, T> {
+impl<T: ?Sized> EventListenerFuture for UpgradableReadArcInner<'_, T> {
     type Output = RwLockUpgradableReadGuardArc<T>;
 
     #[inline]
@@ -323,7 +323,7 @@ impl<T: ?Sized> fmt::Debug for WriteArc<'_, T> {
     }
 }
 
-impl<'a, T: ?Sized> EventListenerFuture for WriteArcInner<'a, T> {
+impl<T: ?Sized> EventListenerFuture for WriteArcInner<'_, T> {
     type Output = RwLockWriteGuardArc<T>;
 
     #[inline]

--- a/src/rwlock/raw.rs
+++ b/src/rwlock/raw.rs
@@ -97,7 +97,6 @@ impl RawRwLock {
     }
 
     /// Returns `true` iff an upgradable read lock was successfully acquired.
-
     pub(super) fn try_upgradable_read(&self) -> bool {
         // First try grabbing the mutex.
         let lock = if let Some(lock) = self.mutex.try_lock() {
@@ -130,7 +129,6 @@ impl RawRwLock {
     }
 
     #[inline]
-
     pub(super) fn upgradable_read(&self) -> RawUpgradableRead<'_> {
         RawUpgradableRead {
             lock: self,
@@ -139,7 +137,6 @@ impl RawRwLock {
     }
 
     /// Returns `true` iff a write lock was successfully acquired.
-
     pub(super) fn try_write(&self) -> bool {
         // First try grabbing the mutex.
         let lock = if let Some(lock) = self.mutex.try_lock() {
@@ -163,7 +160,6 @@ impl RawRwLock {
     }
 
     #[inline]
-
     pub(super) fn write(&self) -> RawWrite<'_> {
         RawWrite {
             lock: self,
@@ -180,7 +176,6 @@ impl RawRwLock {
     ///
     /// Caller must hold an upgradable read lock.
     /// This will attempt to upgrade it to a write lock.
-
     pub(super) unsafe fn try_upgrade(&self) -> bool {
         self.state
             .compare_exchange(ONE_READER, WRITER_BIT, Ordering::AcqRel, Ordering::Acquire)
@@ -191,7 +186,6 @@ impl RawRwLock {
     ///
     /// Caller must hold an upgradable read lock.
     /// This will upgrade it to a write lock.
-
     pub(super) unsafe fn upgrade(&self) -> RawUpgrade<'_> {
         // Set `WRITER_BIT` and decrement the number of readers at the same time.
         self.state
@@ -209,7 +203,6 @@ impl RawRwLock {
     /// Caller must hold an upgradable read lock.
     /// This will downgrade it to a standard read lock.
     #[inline]
-
     pub(super) unsafe fn downgrade_upgradable_read(&self) {
         self.mutex.unlock_unchecked();
     }
@@ -218,7 +211,6 @@ impl RawRwLock {
     ///
     /// Caller must hold a write lock.
     /// This will downgrade it to a read lock.
-
     pub(super) unsafe fn downgrade_write(&self) {
         // Atomically downgrade state.
         self.state
@@ -235,7 +227,6 @@ impl RawRwLock {
     ///
     /// Caller must hold a write lock.
     /// This will downgrade it to an upgradable read lock.
-
     pub(super) unsafe fn downgrade_to_upgradable(&self) {
         // Atomically downgrade state.
         self.state
@@ -246,7 +237,6 @@ impl RawRwLock {
     ///
     /// Caller must hold a read lock .
     /// This will unlock that lock.
-
     pub(super) unsafe fn read_unlock(&self) {
         // Decrement the number of readers.
         if self.state.fetch_sub(ONE_READER, Ordering::SeqCst) & !WRITER_BIT == ONE_READER {
@@ -259,7 +249,6 @@ impl RawRwLock {
     ///
     /// Caller must hold an upgradable read lock.
     /// This will unlock that lock.
-
     pub(super) unsafe fn upgradable_read_unlock(&self) {
         // Decrement the number of readers.
         if self.state.fetch_sub(ONE_READER, Ordering::SeqCst) & !WRITER_BIT == ONE_READER {
@@ -275,7 +264,6 @@ impl RawRwLock {
     ///
     /// Caller must hold a write lock.
     /// This will unlock that lock.
-
     pub(super) unsafe fn write_unlock(&self) {
         // Unset `WRITER_BIT`.
         self.state.fetch_and(!WRITER_BIT, Ordering::SeqCst);

--- a/src/rwlock/raw.rs
+++ b/src/rwlock/raw.rs
@@ -307,7 +307,7 @@ pin_project_lite::pin_project! {
     }
 }
 
-impl<'a> EventListenerFuture for RawRead<'a> {
+impl EventListenerFuture for RawRead<'_> {
     type Output = ();
 
     fn poll_with_strategy<'x, S: Strategy<'x>>(
@@ -372,7 +372,7 @@ pin_project_lite::pin_project! {
     }
 }
 
-impl<'a> EventListenerFuture for RawUpgradableRead<'a> {
+impl EventListenerFuture for RawUpgradableRead<'_> {
     type Output = ();
 
     fn poll_with_strategy<'x, S: Strategy<'x>>(
@@ -455,7 +455,7 @@ pin_project_lite::pin_project! {
     }
 }
 
-impl<'a> EventListenerFuture for RawWrite<'a> {
+impl EventListenerFuture for RawWrite<'_> {
     type Output = ();
 
     fn poll_with_strategy<'x, S: Strategy<'x>>(
@@ -583,7 +583,7 @@ impl<'a> EventListenerFuture for RawUpgrade<'a> {
     }
 }
 
-impl<'a> RawUpgrade<'a> {
+impl RawUpgrade<'_> {
     /// Whether the future returned `Poll::Ready(..)` at some point.
     #[inline]
     pub(super) fn is_ready(&self) -> bool {


### PR DESCRIPTION
See https://github.com/smol-rs/.github/pull/1 for details about reusable workflows.
