### PR TITLE
v3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 3.4.2
+
+- Bump MSRV to 1.85. (#103)
+- Use Waker::noop() to avoid some unsafe code. (#103)
+
 # Version 3.4.1
 
 - Fix typos in docs. (#89)


### PR DESCRIPTION
- Bump MSRV to 1.85. (#103)
- Use Waker::noop() to avoid some unsafe code. (#103)
